### PR TITLE
Run scraper at minute 30

### DIFF
--- a/.github/workflows/scrape-runs.yaml
+++ b/.github/workflows/scrape-runs.yaml
@@ -2,7 +2,7 @@ name: Scrape and Index Workflow Runs
 
 on:
   schedule:
-    - cron: "5 */1 * * *"
+    - cron: "30 * * * *"
   workflow_dispatch:
     inputs:
       name:


### PR DESCRIPTION
There is a rumour that GitHub gets busy around midnight. Start the scraper at minute 30 to see if it helps avoid getting GitHub Actions runs skipped.