### PR TITLE
ci: Fix always failing dry-run OpenSearch index action

### DIFF
--- a/.github/actions/index/action.yaml
+++ b/.github/actions/index/action.yaml
@@ -66,7 +66,7 @@ runs:
         path: "${{ inputs.temp-dir }}/splits/**"
 
     - name: Fail if any items failed to index
-      if: ${{ steps.bail.outputs.bail != 'bail' }}
+      if: ${{ steps.bail.outputs.bail != 'bail' && inputs.dry-run == 'false' }}
       shell: bash
       working-directory: ${{ inputs.temp-dir }}/splits
       run: |


### PR DESCRIPTION
The OpenSearch index action will always fail during a dry-run because it still checks for missing or incorrect responses from OpenSearch. Since we never make any requests to OpenSearch, that step will always fail.